### PR TITLE
Front-end for ability to check orders for a given wallet.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "eslint-config-next": "13.4.7",
         "next": "13.4.7",
         "postcss": "8.4.24",
-        "prisma": "^4.16.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-resizable": "3.0.5",
@@ -36,7 +35,7 @@
       },
       "devDependencies": {
         "@prisma/client": "^4.16.0",
-        "prisma": "^4.16.0"
+        "prisma": "^4.16.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -676,9 +675,9 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.1.tgz",
-      "integrity": "sha512-gpZG0kGGxfemgvK/LghHdBIz+crHkZjzszja94xp4oytpsXrgt/Ice82MvPsWMleVIniKuARrowtsIsim0PFJQ==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.2.tgz",
+      "integrity": "sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==",
       "dev": true,
       "hasInstallScript": true
     },
@@ -3812,13 +3811,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.1.tgz",
-      "integrity": "sha512-C2Xm7yxHxjFjjscBEW4tmoraPHH/Vyu/A0XABdbaFtoiOZARsxvOM7rwc2iZ0qVxbh0bGBGBWZUSXO/52/nHBQ==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.2.tgz",
+      "integrity": "sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.16.1"
+        "@prisma/engines": "4.16.2"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -5342,9 +5341,9 @@
       }
     },
     "@prisma/engines": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.1.tgz",
-      "integrity": "sha512-gpZG0kGGxfemgvK/LghHdBIz+crHkZjzszja94xp4oytpsXrgt/Ice82MvPsWMleVIniKuARrowtsIsim0PFJQ==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.2.tgz",
+      "integrity": "sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==",
       "dev": true
     },
     "@prisma/engines-version": {
@@ -7465,12 +7464,12 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
     "prisma": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.1.tgz",
-      "integrity": "sha512-C2Xm7yxHxjFjjscBEW4tmoraPHH/Vyu/A0XABdbaFtoiOZARsxvOM7rwc2iZ0qVxbh0bGBGBWZUSXO/52/nHBQ==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.2.tgz",
+      "integrity": "sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==",
       "dev": true,
       "requires": {
-        "@prisma/engines": "4.16.1"
+        "@prisma/engines": "4.16.2"
       }
     },
     "process": {

--- a/package.json
+++ b/package.json
@@ -13,33 +13,32 @@
   },
   "devDependencies": {
     "@prisma/client": "^4.16.0",
-    "prisma": "^4.16.0"
+    "prisma": "^4.16.2"
   },
   "dependencies": {
+    "@codemirror/lang-html": "6.4.5",
+    "@codemirror/lang-javascript": "6.1.9",
+    "@codemirror/lang-json": "6.0.1",
+    "@codemirror/lang-xml": "6.0.2",
+    "@scure/base": "1.1.1",
+    "@scure/btc-signer": "1.0.1",
+    "@tailwindcss/forms": "0.5.3",
+    "@uiw/codemirror-theme-okaidia": "4.21.5",
+    "@uiw/react-codemirror": "4.21.5",
     "autoprefixer": "10.4.14",
     "bitcoin-address-validation": "2.2.1",
     "bitcoinjs-lib": "6.1.3",
     "btc-dapp-js": "0.1.6",
-    "@codemirror/lang-javascript": "6.1.9",
-    "@codemirror/lang-json": "6.0.1",
-    "@codemirror/lang-html": "6.4.5",
-    "@codemirror/lang-xml": "6.0.2",
     "eslint": "8.43.0",
     "eslint-config-next": "13.4.7",
     "next": "13.4.7",
     "postcss": "8.4.24",
-    "prisma": "^4.16.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-resizable": "3.0.5",
     "react-toastify": "9.1.3",
     "sats-connect": "0.2.0",
-    "@scure/base": "1.1.1",
-    "@scure/btc-signer": "1.0.1",
     "tailwindcss": "3.3.2",
-    "@tailwindcss/forms": "0.5.3",
-    "tiny-secp256k1": "2.2.3",
-    "@uiw/react-codemirror": "4.21.5",
-    "@uiw/codemirror-theme-okaidia": "4.21.5"
+    "tiny-secp256k1": "2.2.3"
   }
 }

--- a/src/components/editor/checklist.jsx
+++ b/src/components/editor/checklist.jsx
@@ -1,0 +1,32 @@
+export function CheckList({ visible, codeValue, changeFunc }) {
+  const ordersDict = JSON.parse(codeValue);
+  var formContent = [];
+  for(const [order, selected] of Object.entries(ordersDict)) {
+    formContent.push(<input type="radio" id={order} name={order} value={order} 
+                            checked={selected} onChange={changeFunc}></input>);
+    formContent.push(<label className="p-6" for={order}>{order}</label>);
+    formContent.push(<br></br>);
+  }
+  return (
+    <div className={`${visible ? '' : 'hidden'}`}>
+      <section aria-labelledby="section-1-title">
+        <h2 className="sr-only" id="section-1-title">Recursive Inscription Code</h2>
+        <div className="overflow-hidden rounded-lg bg-white shadow dark:bg-gray-700">
+          <div className="p-6 w-fulls" style={{"font-size": "0.5rem"}}>
+            <form action={changeFunc}>
+              { formContent }
+            </form>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export function getOrderFromEvent(event) {
+  return event.target.name;
+}
+
+export function getCheckedFromEvent(event) {
+  return event.target.checked
+}

--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -1,13 +1,15 @@
 import { getP5WrappedHtml } from '../utils/p5.js';
+import { getOrdersWrappedHtml } from '../utils/orders.js'
 
 export const HTML_TYPE = 'html';
 export const JSON_TYPE = 'json';
 export const SVG_TYPE = 'svg';
 export const P5_TYPE = 'p5';
+export const ORDERS_TYPE = 'orders';
 
 export function b64encodedUrl(contentType, plainHtml) {
   const encodedHtml = btoa(unescape(encodeURIComponent(plainHtml)));
-  return `data:${mimeTypeFor(contentType)};base64,${encodedHtml}`;
+  return `data:${mimeTypeFor(contentType != ORDERS_TYPE ? contentType : HTML_TYPE)};base64,${encodedHtml}`;
 }
 
 export function getCurrentCodeFromOrder(orderData) {
@@ -20,6 +22,8 @@ export function getCurrentCodeFromOrder(orderData) {
       return orderData.get('ordinalsSvg');
     case P5_TYPE:
       return orderData.get('ordinalsP5');
+    case ORDERS_TYPE:
+      return orderData.get('orders');
     default:
       return '';
   }
@@ -28,6 +32,7 @@ export function getCurrentCodeFromOrder(orderData) {
 export function mimeTypeFor(contentType) {
   switch (contentType) {
     case JSON_TYPE:
+    case ORDERS_TYPE:
       return 'application/json';
     case P5_TYPE:
     case HTML_TYPE:
@@ -47,6 +52,8 @@ export function getHtmlPageFor(contentType, plainCode) {
       return plainCode;
     case P5_TYPE:
       return getP5WrappedHtml(plainCode);
+    case ORDERS_TYPE:
+      return getOrdersWrappedHtml(plainCode);
     default:
       throw `Unknown content type ${contentType}`;
   }

--- a/src/utils/orders.js
+++ b/src/utils/orders.js
@@ -1,0 +1,11 @@
+export function getOrdersWrappedHtml(ordersJSON) {
+  const orders = JSON.parse(ordersJSON);
+  return (
+    `<div>
+        ${ Object.keys(orders).map((order) =>
+          orders[order] ? `<img style="width:100%;margin:0px" src="/content/${order}" />` : ''
+        ).join()
+        }
+     </div>`
+  );
+}


### PR DESCRIPTION
This adds a button which the user can click to get to a list of their orders by inscription number. Checking the radio item will preview that inscription's image in the recursive preview frame.

Known bug on full screen -- can't make the selection panel wide enough:
<img width="1280" alt="Screen Shot 2023-10-18 at 2 39 52 PM" src="https://github.com/thaddeusdiamond/btc-toolkit/assets/21323870/d62bd434-4e28-40cd-b4a3-e05351c28004">
