### PR TITLE
Orders Table with Pagination

### DIFF
--- a/src/app/api/orders/route.js
+++ b/src/app/api/orders/route.js
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+
+import prisma from '../../../prisma/prisma.mjs';
+
+
+export async function GET({nextUrl: {searchParams}}) {
+  try {
+    const start = 'start' in searchParams ? searchParams.get('start') : 0
+    const end = 'end' in searchParams ? searchParams.get('end') : 10
+    const orders = await prisma.order.findMany({
+      'skip': start,
+      'take': end-start
+    });
+    return NextResponse.json(orders, {status: 200, statusText: `Found order ${start} - ${end}`});
+  } catch (err) {
+    console.log(err)
+    return NextResponse.json(err, {status: 500, statusText: err});
+  }
+}

--- a/src/app/api/orders/route.js
+++ b/src/app/api/orders/route.js
@@ -2,16 +2,31 @@ import { NextResponse } from 'next/server';
 
 import prisma from '../../../prisma/prisma.mjs';
 
+const DEFAULT_TAKE = 10;
 
 export async function GET({nextUrl: {searchParams}}) {
+  var response = {}
   try {
-    const start = 'start' in searchParams ? searchParams.get('start') : 0
-    const end = 'end' in searchParams ? searchParams.get('end') : 10
-    const orders = await prisma.order.findMany({
-      'skip': start,
-      'take': end-start
-    });
-    return NextResponse.json(orders, {status: 200, statusText: `Found order ${start} - ${end}`});
+    if(searchParams.has('getCount') && searchParams.get('getCount') == 'true') {
+      response['count'] = await prisma.order.count();
+    }
+    const cursor = searchParams.has('cursor') ? searchParams.get('cursor') : 'null';
+    const take = searchParams.has('take') ? parseInt(searchParams.get('take')) : DEFAULT_TAKE;
+    var orders;
+    if (cursor != 'null') {
+      console.log("here");
+      orders = await prisma.order.findMany({
+        'take': take,
+        'skip': 1,
+        'cursor': {'id': cursor}
+      });
+    } else {
+      orders = await prisma.order.findMany({
+        'take': take
+      });
+    }
+    response['orders'] = orders;
+    return NextResponse.json(response, {status: 200, statusText: `Found ${take} orders starting at ${cursor != 'null' ? cursor: 'the beginning'}`});
   } catch (err) {
     console.log(err)
     return NextResponse.json(err, {status: 500, statusText: err});

--- a/src/app/api/orders/route.js
+++ b/src/app/api/orders/route.js
@@ -7,8 +7,11 @@ const DEFAULT_TAKE = 10;
 export async function GET({nextUrl: {searchParams}}) {
   var response = {}
   try {
-    if(searchParams.has('getCount') && searchParams.get('getCount') == 'true') {
-      response['count'] = await prisma.order.count();
+    const address = searchParams.get('address');
+    if (searchParams.has('getCount') && searchParams.get('getCount') == 'true') {
+      response['count'] = await prisma.order.count({
+        'where': {'receive_addr': address}
+      });
     }
     const cursor = searchParams.has('cursor') ? searchParams.get('cursor') : 'null';
     const take = searchParams.has('take') ? parseInt(searchParams.get('take')) : DEFAULT_TAKE;
@@ -18,11 +21,13 @@ export async function GET({nextUrl: {searchParams}}) {
       orders = await prisma.order.findMany({
         'take': take,
         'skip': 1,
-        'cursor': {'id': cursor}
+        'cursor': {'id': cursor},
+        'where': {'receive_addr': address}
       });
     } else {
       orders = await prisma.order.findMany({
-        'take': take
+        'take': take,
+        'where': {'receive_addr': address}
       });
     }
     response['orders'] = orders;

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -238,17 +238,17 @@ export default function Home() {
       </div>
       <div class="mx-auto max-w-3xl px-4 py-5 sm:px-6 lg:max-w-7xl lg:px-8">
         <div class="mx-auto max-w-7xl">
-          <div class="bg-gray-700 py-10 rounded-lg">
+          <div class="rounded-lg shadow bg-white dark:bg-gray-700 py-8 rounded-lg">
             <div class="px-4 sm:px-6 lg:px-8">
               <div class="sm:flex sm:items-center">
                 <div class="sm:flex-auto">
-                  <h1 class="text-base font-semibold leading-6 text-white text-center">My Orders</h1>
+                  <h1 class="text-tangz-blue font-semibold leading-6 dark:text-white text-center">My Orders</h1>
                 </div>
               </div>
-              <div class="mt-8 flow-root">
+              <div class="mt-4 flow-root">
                 <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
                   <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-                    <OrdersTable address={orderData.get('walletAddr')}/>
+                    <OrdersTable orderData={orderData} />
                   </div>
                 </div>
               </div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -17,6 +17,7 @@ import { GroupedButton, SimpleButton } from '../components/widgets/buttons.jsx';
 import { TextInput } from '../components/widgets/input.jsx';
 import { Toggle } from '../components/widgets/toggle.jsx';
 import { CodePad } from '../components/editor/codepad.jsx';
+import { OrdersTable } from '../components/orderstable/orderstable.js';
 
 import { b64encodedUrl, getCurrentCodeFromOrder, getHtmlPageFor, HTML_TYPE, JSON_TYPE, SVG_TYPE, P5_TYPE } from '../utils/html.js';
 
@@ -233,6 +234,26 @@ export default function Home() {
               </div>
             </div>
           </Resizable>
+        </div>
+      </div>
+      <div class="mx-auto max-w-3xl px-4 py-5 sm:px-6 lg:max-w-7xl lg:px-8">
+        <div class="mx-auto max-w-7xl">
+          <div class="bg-gray-700 py-10 rounded-lg">
+            <div class="px-4 sm:px-6 lg:px-8">
+              <div class="sm:flex sm:items-center">
+                <div class="sm:flex-auto">
+                  <h1 class="text-base font-semibold leading-6 text-white text-center">My Orders</h1>
+                </div>
+              </div>
+              <div class="mt-8 flow-root">
+                <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                  <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+                    <OrdersTable />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -248,7 +248,7 @@ export default function Home() {
               <div class="mt-8 flow-root">
                 <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
                   <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-                    <OrdersTable />
+                    <OrdersTable address={orderData.get('walletAddr')}/>
                   </div>
                 </div>
               </div>

--- a/src/components/orderstable/orderstable.js
+++ b/src/components/orderstable/orderstable.js
@@ -2,34 +2,32 @@ import {useState, useEffect} from 'react';
 
 const NUM_ROWS = 3;
 
-export function OrdersTable(address) {
+export function OrdersTable({ orderData }) {
   const [pages, setPages] = useState({});
   const [currentPage, setCurrentPage] = useState(0); // 0-indexed
   const [orders, setOrders] = useState(null);
   const [ordersCount, setOrdersCount] = useState(0);
-  
+
   function updatePages(pageNumber, pageContent) {
-    var currPages = pages;
-    currPages[`${pageNumber}`] = pageContent;
-    setPages(currPages);
+    pages[`${pageNumber}`] = pageContent;
+    setPages({...pages});
   }
 
-  async function initialLoadPage() {
-    var cursor, includeCount, initialPage;
-    cursor = null;
-    includeCount = true;
-    const apiCall = `/api/orders?address=${address}&cursor=${cursor}&take=${NUM_ROWS}&getCount=${includeCount}`
-    const apiResponse = await fetch(apiCall);
-    const responseJSON = await apiResponse.json();
-    initialPage = responseJSON['orders'];
-    setOrdersCount(responseJSON['count']);
-    updatePages(currentPage, initialPage);
-    console.log(pages);
-    setOrders(initialPage);
+  function initialLoadPage(address) {
+    fetch(`/api/orders?address=${address}&cursor=null&take=${NUM_ROWS}&getCount=true`)
+      .then(resp => resp.json())
+      .then(responseJSON => {
+        const initialPage = responseJSON['orders'];
+        setOrdersCount(responseJSON['count']);
+        updatePages(currentPage, initialPage);
+        setOrders(initialPage);
+      });
   }
 
-  useEffect(initialLoadPage, []);
-  
+  useEffect(() => {
+    initialLoadPage(orderData.get("walletAddr"))
+  }, [orderData]);
+
   async function loadNextPage() {
     if ((currentPage + 1) * NUM_ROWS >= ordersCount) {
       return;
@@ -59,70 +57,63 @@ export function OrdersTable(address) {
   }
 
   return (
-  <div>
-    <table class="min-w-full divide-y gray-300">
-      <thead>
-        <tr class="bg-tangz-blue-darker">
-          <th scope="col" class="px-3 py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-white">Order ID</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Price</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Service Fee</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Status</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Created At</th>
-          <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0">
-            <span class="sr-only">Edit</span>
-          </th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-800">
-        {orders != null ? orders.map( (order) => (
-          <tr class="bg-gray-700" key={order}>
-            <td class="whitespace-nowrap px-3 py-4 pl-4 pr-3 text-sm font-medium text-white">{order['id']}</td>
-            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['price']}</td>
-            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['service_fee']}</td>
-            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['status']}</td>
-            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['createdAt']}</td>
-            <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
-            </td>
+    <div>
+      <table class="min-w-full divide-y gray-300">
+        <thead>
+          <tr class="bg-tangz-blue-darker">
+            <th scope="col" class="px-3 py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-white">Order ID</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Cost (sats)</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Status</th>
+            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Created At</th>
           </tr>
-        )): ""}
-      </tbody>
-    </table>
-    <div class="flex items-center justify-between border-t border-gray-200 bg-gray-700 px-4 py-3 sm:px-6">
-    <div class="flex flex-1 justify-between sm:hidden">
-      <a href="#" class="relative inline-flex items-center rounded-md border border-gray-300 bg-gray-700 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-50">Previous</a>
-      <a href="#" class="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-gray-700 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-50">Next</a>
-    </div>
-    <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
-      <div>
-        <p class="text-sm text-gray-300">
-          Showing
-          <span class="font-medium"> {ordersCount ? (currentPage * NUM_ROWS) + 1 : 0} </span>
-          to
-          <span class="font-medium"> {Math.min((currentPage + 1) * NUM_ROWS, ordersCount)} </span>
-          of
-          <span class="font-medium"> {ordersCount} </span>
-          results
-        </p>
+        </thead>
+        <tbody class="divide-y divide-gray-700 dark:divide-gray-300">
+          {orders != null ? orders.map( (order) => (
+            <tr key={order}>
+              <td class="whitespace-nowrap px-3 py-4 pl-4 pr-3 text-sm font-medium text-gray-700 dark:text-white">{order['id']}</td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-700 dark:text-white">{order['price']}</td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-700 dark:text-white">{order['status']}</td>
+              <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-700 dark:text-white">{order['createdAt']}</td>
+            </tr>
+          )): ""}
+        </tbody>
+      </table>
+      <div class="flex items-center justify-between border-t border-gray-700 dark:border-gray-300 px-4 py-3 sm:px-6">
+        <div class="flex flex-1 justify-between sm:hidden">
+          <a href="#" class="relative inline-flex items-center rounded-md border dark:border-gray-300 bg-gray-700 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-50">Previous</a>
+          <a href="#" class="relative ml-3 inline-flex items-center rounded-md border dark:border-gray-300 bg-gray-700 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-50">Next</a>
+        </div>
+        <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
+          <div>
+            <p class="text-sm text-gray-700 dark:text-white">
+              Showing
+              <span class="font-medium"> {ordersCount ? (currentPage * NUM_ROWS) + 1 : 0} </span>
+              to
+              <span class="font-medium"> {Math.min((currentPage + 1) * NUM_ROWS, ordersCount)} </span>
+              of
+              <span class="font-medium"> {ordersCount} </span>
+              results
+            </p>
+          </div>
+          <div>
+            <nav class="isolate inline-flex -space-x-px rounded-md shadow-sm text-gray-700 dark:text-white" aria-label="Pagination">
+              <a onClick={loadPreviousPage} class="relative inline-flex items-center rounded-l-md px-2 py-2 ring-1 ring-inset ring-gray-300 hover:bg-tangz-blue-darker hover:text-white focus:z-20 focus:outline-offset-0">
+                <span class="sr-only">Previous</span>
+                <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" />
+                </svg>
+              </a>
+              <a class="relative inline-flex items-center px-4 py-2 text-sm font-semibold ring-1 ring-inset ring-gray-300 focus:z-20 focus:outline-offset-0">{currentPage+1}</a>
+              <a onClick={loadNextPage} class="relative inline-flex items-center rounded-r-md px-2 py-2 ring-1 ring-inset ring-gray-300 hover:bg-tangz-blue-darker hover:text-white focus:z-20 focus:outline-offset-0">
+                <span class="sr-only">Next</span>
+                <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+                </svg>
+              </a>
+            </nav>
+          </div>
+        </div>
       </div>
-      <div>
-        <nav class="isolate inline-flex -space-x-px rounded-md shadow-sm" aria-label="Pagination">
-          <a onClick={loadPreviousPage} class="relative inline-flex items-center rounded-l-md px-2 py-2 text-gray-300 ring-1 ring-inset ring-gray-300 hover:bg-tangz-blue-darker focus:z-20 focus:outline-offset-0">
-            <span class="sr-only">Previous</span>
-            <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" />
-            </svg>
-          </a>
-          <a class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-gray-300 ring-1 ring-inset ring-gray-300 focus:z-20 focus:outline-offset-0">{currentPage+1}</a>
-          <a onClick={loadNextPage} class="relative inline-flex items-center rounded-r-md px-2 py-2 text-gray-300 ring-1 ring-inset ring-gray-300 hover:bg-tangz-blue-darker focus:z-20 focus:outline-offset-0">
-            <span class="sr-only">Next</span>
-            <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
-            </svg>
-          </a>
-        </nav>
-      </div>
     </div>
-  </div>
-  </div>
   );
 }

--- a/src/components/orderstable/orderstable.js
+++ b/src/components/orderstable/orderstable.js
@@ -1,0 +1,51 @@
+import {useState} from 'react';
+
+export function OrdersTable() {
+  const [tableStart, setTableStart] = useState(0);
+  const [orders, setOrders] = useState(null);
+
+  async function getOrders(start) {
+    if (orders == null || tableStart != start) {
+      const apiResponse = await fetch(`/api/orders?start=0&end=10`);
+      const newOrders = await apiResponse.json();
+      setOrders(newOrders);
+      setTableStart(start);
+    } 
+    return orders;
+  }
+  const myOrders = getOrders(0); // TODO: Add pagination
+  return (
+    <table class="min-w-full divide-y gray-300">
+      <thead>
+        <tr class="bg-tangz-blue-darker">
+          <th scope="col" class="px-3 py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-white">Order ID</th>
+          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Receive Address</th>
+          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Price</th>
+          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Service Fee</th>
+          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Status</th>
+          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Created At</th>
+          <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0">
+            <span class="sr-only">Edit</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-800">
+        {console.log(typeof orders)}
+        {orders != null ? orders.map( (order) => (
+          <tr class="bg-gray-700">
+          <td class="whitespace-nowrap px-3 py-4 pl-4 pr-3 text-sm font-medium text-white">{order['id']}</td>
+          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['receive_addr']}</td>
+          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['price']}</td>
+          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['service_fee']}</td>
+          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['status']}</td>
+          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['createdAt']}</td>
+          <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
+          </td>
+        </tr>
+        )): ""}
+        {/* <!-- More orders... --> */}
+      </tbody>
+    </table>
+
+  );
+}

--- a/src/components/orderstable/orderstable.js
+++ b/src/components/orderstable/orderstable.js
@@ -1,20 +1,66 @@
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
+
+const NUM_ROWS = 3;
 
 export function OrdersTable() {
-  const [tableStart, setTableStart] = useState(0);
+  const [pages, setPages] = useState({});
+  const [currentPage, setCurrentPage] = useState(0); // 0-indexed
   const [orders, setOrders] = useState(null);
+  const [ordersCount, setOrdersCount] = useState(0)
 
-  async function getOrders(start) {
-    if (orders == null || tableStart != start) {
-      const apiResponse = await fetch(`/api/orders?start=0&end=10`);
-      const newOrders = await apiResponse.json();
-      setOrders(newOrders);
-      setTableStart(start);
-    } 
-    return orders;
+  
+  function updatePages(pageNumber, pageContent) {
+    var currPages = pages;
+    currPages[`${pageNumber}`] = pageContent;
+    setPages(currPages);
   }
-  const myOrders = getOrders(0); // TODO: Add pagination
+
+  async function initialLoadPage() {
+    var cursor, includeCount, initialPage;
+    cursor = null;
+    includeCount = true;
+    const apiCall = `/api/orders?cursor=${cursor}&take=${NUM_ROWS}&getCount=${includeCount}`
+    const apiResponse = await fetch(apiCall);
+    const responseJSON = await apiResponse.json();
+    initialPage = responseJSON['orders'];
+    setOrdersCount(responseJSON['count']);
+    updatePages(currentPage, initialPage);
+    console.log(pages);
+    setOrders(initialPage);
+  }
+
+  useEffect(initialLoadPage, []);
+  
+  async function loadNextPage() {
+    if((currentPage + 1)*NUM_ROWS >= ordersCount) {
+      return;
+    }
+    const includeCount = false
+    var cursor, nextPage;
+    cursor = orders.slice(-1)[0]['id'];
+    if(`${currentPage+1}` in pages) {
+      nextPage = pages[`${currentPage+1}`];
+    } else {
+      const apiCall = `/api/orders?cursor=${cursor}&take=${NUM_ROWS}&getCount=${includeCount}`
+      const apiResponse = await fetch(apiCall);
+      const responseJSON = await apiResponse.json();
+      nextPage = responseJSON['orders'];
+      updatePages(currentPage+1, nextPage);
+    }
+    setCurrentPage(currentPage+1);
+    setOrders(nextPage);
+  }
+
+  function loadPreviousPage() {
+    if(currentPage == 0)  {
+      return;
+    }
+    setOrders(pages[`${currentPage-1}`]);
+    setCurrentPage(currentPage - 1);
+  }
+
   return (
+  <div>
     <table class="min-w-full divide-y gray-300">
       <thead>
         <tr class="bg-tangz-blue-darker">
@@ -30,22 +76,57 @@ export function OrdersTable() {
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-800">
-        {console.log(typeof orders)}
         {orders != null ? orders.map( (order) => (
-          <tr class="bg-gray-700">
-          <td class="whitespace-nowrap px-3 py-4 pl-4 pr-3 text-sm font-medium text-white">{order['id']}</td>
-          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['receive_addr']}</td>
-          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['price']}</td>
-          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['service_fee']}</td>
-          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['status']}</td>
-          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['createdAt']}</td>
-          <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
-          </td>
-        </tr>
+          <tr class="bg-gray-700" key={order}>
+            <td class="whitespace-nowrap px-3 py-4 pl-4 pr-3 text-sm font-medium text-white">{order['id']}</td>
+            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['receive_addr']}</td>
+            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['price']}</td>
+            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['service_fee']}</td>
+            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['status']}</td>
+            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['createdAt']}</td>
+            <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
+            </td>
+          </tr>
         )): ""}
-        {/* <!-- More orders... --> */}
       </tbody>
     </table>
-
+    <div class="flex items-center justify-between border-t border-gray-200 bg-gray-700 px-4 py-3 sm:px-6">
+    <div class="flex flex-1 justify-between sm:hidden">
+      <a href="#" class="relative inline-flex items-center rounded-md border border-gray-300 bg-gray-700 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-50">Previous</a>
+      <a href="#" class="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-gray-700 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-50">Next</a>
+    </div>
+    <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
+      <div>
+        <p class="text-sm text-gray-300">
+          Showing
+          <span class="font-medium"> {(currentPage * NUM_ROWS) + 1} </span>
+          to
+          <span class="font-medium"> {Math.min((currentPage + 1) * NUM_ROWS, ordersCount)} </span>
+          of
+          <span class="font-medium"> {ordersCount} </span>
+          results
+        </p>
+      </div>
+      <div>
+        <nav class="isolate inline-flex -space-x-px rounded-md shadow-sm" aria-label="Pagination">
+          <a onClick={loadPreviousPage} class="relative inline-flex items-center rounded-l-md px-2 py-2 text-gray-300 ring-1 ring-inset ring-gray-300 hover:bg-tangz-blue-darker focus:z-20 focus:outline-offset-0">
+            <span class="sr-only">Previous</span>
+            <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" />
+            </svg>
+          </a>
+          {/* <!-- Current: "z-10 bg-indigo-600 text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600", Default: "text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:outline-offset-0" --> */}
+          <a class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-gray-300 ring-1 ring-inset ring-gray-300 focus:z-20 focus:outline-offset-0">{currentPage+1}</a>
+          <a onClick={loadNextPage} class="relative inline-flex items-center rounded-r-md px-2 py-2 text-gray-300 ring-1 ring-inset ring-gray-300 hover:bg-tangz-blue-darker focus:z-20 focus:outline-offset-0">
+            <span class="sr-only">Next</span>
+            <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+            </svg>
+          </a>
+        </nav>
+      </div>
+    </div>
+  </div>
+  </div>
   );
 }

--- a/src/components/orderstable/orderstable.js
+++ b/src/components/orderstable/orderstable.js
@@ -2,12 +2,11 @@ import {useState, useEffect} from 'react';
 
 const NUM_ROWS = 3;
 
-export function OrdersTable() {
+export function OrdersTable(address) {
   const [pages, setPages] = useState({});
   const [currentPage, setCurrentPage] = useState(0); // 0-indexed
   const [orders, setOrders] = useState(null);
-  const [ordersCount, setOrdersCount] = useState(0)
-
+  const [ordersCount, setOrdersCount] = useState(0);
   
   function updatePages(pageNumber, pageContent) {
     var currPages = pages;
@@ -19,7 +18,7 @@ export function OrdersTable() {
     var cursor, includeCount, initialPage;
     cursor = null;
     includeCount = true;
-    const apiCall = `/api/orders?cursor=${cursor}&take=${NUM_ROWS}&getCount=${includeCount}`
+    const apiCall = `/api/orders?address=${address}&cursor=${cursor}&take=${NUM_ROWS}&getCount=${includeCount}`
     const apiResponse = await fetch(apiCall);
     const responseJSON = await apiResponse.json();
     initialPage = responseJSON['orders'];
@@ -32,16 +31,16 @@ export function OrdersTable() {
   useEffect(initialLoadPage, []);
   
   async function loadNextPage() {
-    if((currentPage + 1)*NUM_ROWS >= ordersCount) {
+    if ((currentPage + 1) * NUM_ROWS >= ordersCount) {
       return;
     }
     const includeCount = false
     var cursor, nextPage;
     cursor = orders.slice(-1)[0]['id'];
-    if(`${currentPage+1}` in pages) {
+    if (`${currentPage + 1}` in pages) {
       nextPage = pages[`${currentPage+1}`];
     } else {
-      const apiCall = `/api/orders?cursor=${cursor}&take=${NUM_ROWS}&getCount=${includeCount}`
+      const apiCall = `/api/orders?address=${address}&cursor=${cursor}&take=${NUM_ROWS}&getCount=${includeCount}`
       const apiResponse = await fetch(apiCall);
       const responseJSON = await apiResponse.json();
       nextPage = responseJSON['orders'];
@@ -52,7 +51,7 @@ export function OrdersTable() {
   }
 
   function loadPreviousPage() {
-    if(currentPage == 0)  {
+    if (currentPage == 0)  {
       return;
     }
     setOrders(pages[`${currentPage-1}`]);
@@ -65,7 +64,6 @@ export function OrdersTable() {
       <thead>
         <tr class="bg-tangz-blue-darker">
           <th scope="col" class="px-3 py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-white">Order ID</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Receive Address</th>
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Price</th>
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Service Fee</th>
           <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-white">Status</th>
@@ -79,7 +77,6 @@ export function OrdersTable() {
         {orders != null ? orders.map( (order) => (
           <tr class="bg-gray-700" key={order}>
             <td class="whitespace-nowrap px-3 py-4 pl-4 pr-3 text-sm font-medium text-white">{order['id']}</td>
-            <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['receive_addr']}</td>
             <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['price']}</td>
             <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['service_fee']}</td>
             <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-300">{order['status']}</td>
@@ -99,7 +96,7 @@ export function OrdersTable() {
       <div>
         <p class="text-sm text-gray-300">
           Showing
-          <span class="font-medium"> {(currentPage * NUM_ROWS) + 1} </span>
+          <span class="font-medium"> {ordersCount ? (currentPage * NUM_ROWS) + 1 : 0} </span>
           to
           <span class="font-medium"> {Math.min((currentPage + 1) * NUM_ROWS, ordersCount)} </span>
           of
@@ -115,7 +112,6 @@ export function OrdersTable() {
               <path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" />
             </svg>
           </a>
-          {/* <!-- Current: "z-10 bg-indigo-600 text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600", Default: "text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:outline-offset-0" --> */}
           <a class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-gray-300 ring-1 ring-inset ring-gray-300 focus:z-20 focus:outline-offset-0">{currentPage+1}</a>
           <a onClick={loadNextPage} class="relative inline-flex items-center rounded-r-md px-2 py-2 text-gray-300 ring-1 ring-inset ring-gray-300 hover:bg-tangz-blue-darker focus:z-20 focus:outline-offset-0">
             <span class="sr-only">Next</span>


### PR DESCRIPTION
This code is tested with mock data. It should be tried with a real order to see how it handles. UI could be more responsive, for example changing color based on the order's status.
<img width="1248" alt="Screen Shot 2023-10-23 at 5 04 52 PM" src="https://github.com/thaddeusdiamond/btc-toolkit/assets/21323870/11ed9bc3-83e4-4d49-86e1-2a6a57bed2ce">

 
<img width="1259" alt="Screen Shot 2023-10-23 at 5 05 04 PM" src="https://github.com/thaddeusdiamond/btc-toolkit/assets/21323870/b5c03d08-c962-42d8-b995-57e0a051671a">
