### PR TITLE
feat(Collection Discounts): Enable discounts for the dev fee for certain collections

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -47,10 +47,13 @@ function Header() {
 function Footer() {
   return (
     <footer>
-      <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
-        <div className="flex flex-wrap md:flex-nowrap justify-between border-t border-gray-200 py-8 gap-4 text-center text-sm text-gray-500">
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:max-w-7xl lg:px-8 border-t border-gray-200 w-full py-4 text-center text-sm text-gray-500">
+        <div className="mx-auto mb-4 italic">
+          Please note, we charge 4,000 sats (0.00004 BTC) per inscription as a developer fee. Certain collections, such as the <a href="https://otternals.io/mint" target="_blank" className="text-tangz-blue hover:underline">Otternals</a>, may receive discounts on these costs.
+        </div>
+        <div className="flex flex-wrap md:flex-nowrap justify-between gap-4">
           <span className="block sm:inline mx-auto md:mx-0">&copy; 2023 Wild Tangz. All rights reserved.</span>
-          <span className="block sm:inline mx-auto md:mx-0">Questions? Get in touch via <a href="https://discord.gg/wildtangz" className="text-tangz-blue hover:underline">Wild Tangz Discord</a></span>
+          <span className="block sm:inline mx-auto md:mx-0">Questions? Get in touch via <a href="https://discord.gg/wildtangz" target="_blank" className="text-tangz-blue hover:underline">Wild Tangz Discord</a></span>
         </div>
       </div>
     </footer>
@@ -63,7 +66,7 @@ export default function RootLayout({ children }) {
       <UserProvider>
         <body className={inter.className}>
           <Header />
-          <main className="pb-8">
+          <main className="pb-4">
             <TermsAndConditionsModal id="btc-toolkit-info-firsttimer" header="Please Read Carefully" confirmation="I Understand" expiration={TWO_WEEKS_MS}>
               <span>The following interface attempts its best to render a preview of your recursive Ordinal.  Please, CAREFULLY inspect the code you enter below.  There are no refunds once orders are processed.</span>
             </TermsAndConditionsModal>

--- a/src/utils/price.js
+++ b/src/utils/price.js
@@ -1,0 +1,28 @@
+const COLLECTION_DISCOUNTS = process.env.COLLECTION_DISCOUNTS ? JSON.parse(process.env.COLLECTION_DISCOUNTS) : [];
+const DEFAULT_PRICE = 4000;
+
+function getCollectionUrl(symbol, owner) {
+  return `https://api-mainnet.magiceden.dev/v2/ord/btc/tokens?collectionSymbol=${symbol}&ownerAddress=${owner}&showAll=true&sortBy=priceAsc`;
+}
+
+export async function getFee(buyerAddress) {
+  try {
+    let existingDiscount = 0.0;
+    for (const collectionDiscount of COLLECTION_DISCOUNTS) {
+      const discountHeaders = {};
+      for (const header in collectionDiscount.headers) {
+        discountHeaders[header] = collectionDiscount.headers[header];
+      }
+      const discountResult = await fetch(getCollectionUrl(collectionDiscount.symbol, buyerAddress), {
+        headers: discountHeaders
+      }).then(res => res.json());
+      const collectionDiscountResult = collectionDiscount.pct * discountResult.total;
+      console.log(`${buyerAddress} has a discount of ${collectionDiscountResult * 100}% from "${collectionDiscount.symbol}" holdings`);
+      existingDiscount += collectionDiscountResult;
+    }
+    return Math.max(DEFAULT_PRICE * (1 - existingDiscount), 0);
+  } catch (err) {
+    console.error(err);
+    return DEFAULT_PRICE;
+  }
+}


### PR DESCRIPTION
Previously, we were charging a flat 4k sats per inscription.  However, we occassionally will want to discount this utility (e.g., for the Otternals).  So, we add an environment variable to detect a list of URLs where collections are housed (conforming to the following ME spec): https://docs.magiceden.io/reference/gettokens-1

NOTE: We add a little disclaimer on the footer to make the pricing slightly clearer.

[ Testing: npm run build, manual QA ]